### PR TITLE
refactor: 출국장·주차장 도메인에 Value Object 패턴 적용

### DIFF
--- a/src/main/java/com/example/chat/airport/departure/Departure.java
+++ b/src/main/java/com/example/chat/airport/departure/Departure.java
@@ -1,10 +1,9 @@
 package com.example.chat.airport.departure;
 
+import com.example.chat.airport.departure.vo.T1GateStatus;
+import com.example.chat.airport.departure.vo.T2GateStatus;
 import com.example.chat.common.BaseTime;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +15,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 public class Departure extends BaseTime {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,31 +23,26 @@ public class Departure extends BaseTime {
 
     private String timeZone;
 
-    private Long t1Depart1;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "gate1", column = @Column(name = "t1_depart1")),
+            @AttributeOverride(name = "gate2", column = @Column(name = "t1_depart2")),
+            @AttributeOverride(name = "gate3", column = @Column(name = "t1_depart3")),
+            @AttributeOverride(name = "gate4", column = @Column(name = "t1_depart4")),
+            @AttributeOverride(name = "gate5", column = @Column(name = "t1_depart5")),
+            @AttributeOverride(name = "gate6", column = @Column(name = "t1_depart6")),
+    })
+    private T1GateStatus t1Gates;
 
-    private Long t1Depart2;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "gate1", column = @Column(name = "t2_depart1")),
+            @AttributeOverride(name = "gate2", column = @Column(name = "t2_depart2")),
+    })
+    private T2GateStatus t2Gates;
 
-    private Long t1Depart3;
-
-    private Long t1Depart4;
-
-    private Long t1Depart5;
-
-    private Long t1Depart6;
-
-    private Long t2Depart1;
-
-    private Long t2Depart2;
-
-    public void updateDeparture(long t1Depart1, long t1Depart2, long t1Depart3, long t1Depart4,
-                                long t1Depart5, long t1Depart6, long t2Depart1, long t2Depart2) {
-        this.t1Depart1 = t1Depart1;
-        this.t1Depart2 = t1Depart2;
-        this.t1Depart3 = t1Depart3;
-        this.t1Depart4 = t1Depart4;
-        this.t1Depart5 = t1Depart5;
-        this.t1Depart6 = t1Depart6;
-        this.t2Depart1 = t2Depart1;
-        this.t2Depart2 = t2Depart2;
+    public void updateDeparture(T1GateStatus t1Gates, T2GateStatus t2Gates) {
+        this.t1Gates = t1Gates;
+        this.t2Gates = t2Gates;
     }
 }

--- a/src/main/java/com/example/chat/airport/departure/dto/DepartureResDto.java
+++ b/src/main/java/com/example/chat/airport/departure/dto/DepartureResDto.java
@@ -36,14 +36,14 @@ public class DepartureResDto {
         return DepartureResDto.builder()
                 .date(departure.getDate())
                 .timeZone(departure.getTimeZone())
-                .t1Depart1(departure.getT1Depart1())
-                .t1Depart2(departure.getT1Depart2())
-                .t1Depart3(departure.getT1Depart3())
-                .t1Depart4(departure.getT1Depart4())
-                .t1Depart5(departure.getT1Depart5())
-                .t1Depart6(departure.getT1Depart6())
-                .t2Depart1(departure.getT2Depart1())
-                .t2Depart2(departure.getT2Depart2())
+                .t1Depart1(departure.getT1Gates().getGate1())
+                .t1Depart2(departure.getT1Gates().getGate2())
+                .t1Depart3(departure.getT1Gates().getGate3())
+                .t1Depart4(departure.getT1Gates().getGate4())
+                .t1Depart5(departure.getT1Gates().getGate5())
+                .t1Depart6(departure.getT1Gates().getGate6())
+                .t2Depart1(departure.getT2Gates().getGate1())
+                .t2Depart2(departure.getT2Gates().getGate2())
                 .build();
     }
 }

--- a/src/main/java/com/example/chat/airport/departure/vo/T1GateStatus.java
+++ b/src/main/java/com/example/chat/airport/departure/vo/T1GateStatus.java
@@ -1,0 +1,28 @@
+package com.example.chat.airport.departure.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 제1여객터미널 출국장 게이트별 대기 인원
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class T1GateStatus {
+    private Long gate1;
+    private Long gate2;
+    private Long gate3;
+    private Long gate4;
+    private Long gate5;
+    private Long gate6;
+
+    public long sum() {
+        return gate1 + gate2 + gate3 + gate4 + gate5 + gate6;
+    }
+
+    public boolean isBusy(long threshold) {
+        return sum() >= threshold;
+    }
+}

--- a/src/main/java/com/example/chat/airport/departure/vo/T2GateStatus.java
+++ b/src/main/java/com/example/chat/airport/departure/vo/T2GateStatus.java
@@ -1,0 +1,25 @@
+package com.example.chat.airport.departure.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 제2여객터미널 출국장 게이트별 대기 인원 */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class T2GateStatus {
+
+    private Long gate1;
+    private Long gate2;
+
+    public long sum() {
+        return gate1 + gate2;
+    }
+
+    public boolean isBusy(long threshold) {
+        return sum() >= threshold;
+    }
+}

--- a/src/main/java/com/example/chat/airport/parking/Parking.java
+++ b/src/main/java/com/example/chat/airport/parking/Parking.java
@@ -1,5 +1,6 @@
 package com.example.chat.airport.parking;
 
+import com.example.chat.airport.parking.vo.ParkingCapacity;
 import com.example.chat.common.BaseTime;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -15,33 +16,22 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "parking")
 public class Parking extends BaseTime {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 주차구역 문자열 (예: "T1 장기 P1 주차장")
+    // 주차구역 문자열
     @Column(unique = true)
     private String floor;
 
-    // 현재 주차대수
-    private int parking;
+    @Embedded
+    private ParkingCapacity capacity;
 
-    // 총 주차면수 (0이면 미운영)
-    private int parkingarea;
-
-    // 업데이트 시간 (ex. "20211103162024.804")
+    // 업데이트 시간
     private String datetm;
 
-    public void updateParking(int parking, int parkingarea, String datetm) {
-        this.parking = parking;
-        this.parkingarea = parkingarea;
+    public void updateParking(ParkingCapacity capacity, String datetm) {
+        this.capacity = capacity;
         this.datetm = datetm;
-    }
-
-    // 가용률 계산 (0~100%, 미운영 시 -1)
-    public int getAvailableRate() {
-        if (parkingarea == 0) return -1;
-        return (parkingarea - parking) * 100 / parkingarea;
     }
 }

--- a/src/main/java/com/example/chat/airport/parking/ParkingService.java
+++ b/src/main/java/com/example/chat/airport/parking/ParkingService.java
@@ -1,6 +1,7 @@
 package com.example.chat.airport.parking;
 
 import com.example.chat.airport.parking.dto.ParkingResDto;
+import com.example.chat.airport.parking.vo.ParkingCapacity;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,24 +15,24 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 public class ParkingService {
-
     private final ParkingRepository parkingRepository;
 
     @Transactional
     public void upsertParkingData(JsonNode items) {
         for (JsonNode item : items) {
             String floor = item.path("floor").asText();
-            int parking = item.path("parking").asInt();
-            int parkingarea = item.path("parkingarea").asInt();
+            ParkingCapacity capacity = new ParkingCapacity(
+                    item.path("parking").asInt(),
+                    item.path("parkingarea").asInt()
+            );
             String datetm = item.path("datetm").asText();
 
             parkingRepository.findByFloor(floor)
                     .ifPresentOrElse(
-                            exists -> exists.updateParking(parking, parkingarea, datetm), // 이미 존재하는 데이터면
-                            () -> parkingRepository.save(Parking.builder() // 새로운 데이터면
+                            exists -> exists.updateParking(capacity, datetm),
+                            () -> parkingRepository.save(Parking.builder()
                                     .floor(floor)
-                                    .parking(parking)
-                                    .parkingarea(parkingarea)
+                                    .capacity(capacity)
                                     .datetm(datetm)
                                     .build())
                     );

--- a/src/main/java/com/example/chat/airport/parking/dto/ParkingResDto.java
+++ b/src/main/java/com/example/chat/airport/parking/dto/ParkingResDto.java
@@ -16,9 +16,9 @@ public class ParkingResDto {
     public static ParkingResDto from(Parking parking) {
         return ParkingResDto.builder()
                 .floor(parking.getFloor())
-                .parking(parking.getParking())
-                .parkingarea(parking.getParkingarea())
-                .availableRate(parking.getAvailableRate())
+                .parking(parking.getCapacity().getParking())
+                .parkingarea(parking.getCapacity().getParkingarea())
+                .availableRate(parking.getCapacity().getAvailableRate())
                 .datetm(parking.getDatetm())
                 .build();
     }

--- a/src/main/java/com/example/chat/airport/parking/vo/ParkingCapacity.java
+++ b/src/main/java/com/example/chat/airport/parking/vo/ParkingCapacity.java
@@ -1,0 +1,22 @@
+package com.example.chat.airport.parking.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 주차 구역의 현재 주차 대수와 총 주차 면수 */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class ParkingCapacity {
+    private int parking;      // 현재 주차 대수
+    private int parkingarea;  // 총 주차 면수 (0이면 미운영)
+
+    // 가용률 계산 (0~100%, 미운영 시 -1)
+    public int getAvailableRate() {
+        if (parkingarea == 0) return -1;
+        return (parkingarea - parking) * 100 / parkingarea;
+    }
+}


### PR DESCRIPTION
## 변경 내용

**신규 Value Object**
- `T1GateStatus` — T1 터미널 게이트 1~6 혼잡도 묶음, `sum()`, `isBusy(threshold)` 제공
- `T2GateStatus` — T2 터미널 게이트 1~2 혼잡도 묶음
- `ParkingCapacity` — 주차 대수/면수 묶음, `getAvailableRate()` 제공

**엔티티 적용**
- `Departure`: 8개 flat 필드 → `@Embedded T1GateStatus`, `T2GateStatus`로 교체
- `Parking`: `parking`, `parkingarea` 필드 → `@Embedded ParkingCapacity`로 교체

**연관 클래스 수정**
- `DepartureResDto`, `ParkingResDto`: VO getter로 변경 (API 응답 구조 유지)
- `ParkingService`: ParkingCapacity 객체로 생성

## 변경 이유

`sum()`, `isBusy()`, `getAvailableRate()` 같은 도메인 로직이 Service에 흩어져 있어 VO로 응집했습니다.
JPA `@Embeddable`을 사용하여 DB 스키마 변경 없이 적용했습니다.