### PR TITLE
refactor: plane 패키지 미사용 코드 제거, 책임 분리 및 권한 추가

### DIFF
--- a/src/main/java/com/example/chat/airport/ApiService.java
+++ b/src/main/java/com/example/chat/airport/ApiService.java
@@ -3,6 +3,7 @@ package com.example.chat.airport;
 import com.example.chat.airport.departure.DepartureService;
 import com.example.chat.airport.parking.ParkingService;
 import com.example.chat.airport.plane.PlaneService;
+import com.example.chat.common.DateUtils;
 import com.example.chat.exception.ChatException;
 import com.example.chat.exception.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,6 +18,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -44,6 +46,19 @@ public class ApiService {
             "http://apis.data.go.kr/B551177/StatusOfParking/getTrackingParking";
 
     private final List<String> departureSearchDates = List.of("0", "1");
+
+    // 어제~모레(4일치) 항공편 일괄 동기화
+    public void syncPlaneDataForDays() {
+        for (int offset = -1; offset <= 2; offset++) {
+            String date = LocalDate.now().plusDays(offset).format(DateUtils.BASIC_DATE);
+            try {
+                fetchAndSyncPlaneData(date);
+                log.info("{}일({}) 항공편 수동 동기화 완료", offset, date);
+            } catch (Exception e) {
+                log.error("{}일({}) 항공편 수동 동기화 실패", offset, date, e);
+            }
+        }
+    }
 
     // 단일 날짜 항공편 동기화
     public void fetchAndSyncPlaneData(String searchDate) {

--- a/src/main/java/com/example/chat/airport/plane/PlaneController.java
+++ b/src/main/java/com/example/chat/airport/plane/PlaneController.java
@@ -2,16 +2,11 @@ package com.example.chat.airport.plane;
 
 import com.example.chat.airport.ApiService;
 import com.example.chat.airport.plane.dto.PlaneResDto;
-import com.example.chat.common.DateUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,19 +29,11 @@ public class PlaneController {
     // 어제~모레 항공편 동기화
     @PostMapping("/planes/sync")
     public void syncAllPlanes() {
-        for (int offset = -1; offset <= 2; offset++) {
-            String date = LocalDate.now().plusDays(offset).format(DateUtils.BASIC_DATE);
-
-            try {
-                apiService.fetchAndSyncPlaneData(date);
-                log.info("{}일({}) 항공편 수동 동기화 완료", offset, date);
-            } catch (Exception e) {
-                log.error("{}일({}) 항공편 수동 동기화 실패", offset, date, e);
-            }
-        }
+        apiService.syncPlaneDataForDays();
     }
 
     // 모든 항공편 데이터 삭제
+    @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/planes/deleteAll")
     public void deleteAllPlanes() {
         planeService.deleteAll();

--- a/src/main/java/com/example/chat/airport/plane/PlaneService.java
+++ b/src/main/java/com/example/chat/airport/plane/PlaneService.java
@@ -1,26 +1,25 @@
 package com.example.chat.airport.plane;
 
 import com.example.chat.airport.plane.dto.PlaneResDto;
+import com.example.chat.airport.plane.event.FlightIndexingEvent;
+import com.example.chat.airport.plane.event.PlaneChangedEvent;
 import com.example.chat.common.DateUtils;
-import com.example.chat.kafka.message.PlaneChangedMessage;
-import com.example.chat.kafka.message.PlaneIndexingMessage;
 import com.example.chat.airport.plane.repository.PlaneRepository;
 import com.example.chat.airport.search.FlightSearchService;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
-import static com.example.chat.kafka.KafkaTopics.TOPIC_INDEXING;
-import static com.example.chat.kafka.KafkaTopics.TOPIC_CHANGED;
 
 
 @Slf4j
@@ -29,16 +28,13 @@ import static com.example.chat.kafka.KafkaTopics.TOPIC_CHANGED;
 public class PlaneService {
     private final PlaneRepository planeRepository;
     private final FlightSearchService flightSearchService;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     // API를 통해 조회한 공항 항공편 현황 데이터를 DB에 저장 및 갱신
     @Transactional
     public void upsertPlaneData(JsonNode jsonPlaneData, String searchDate) {
-        // DB에 존재하는 특정 searchDate 항공편 데이터 전부 가져오기
         List<Plane> existPlaneDb = getPlanesBySearchDate(searchDate);
 
-        // 기존에 존재하는 항공편 데이터를 Map에 key-value 형태로 저장
-        // key : "FlightId"_"scheduleDateTime" 형태
         Map<String, Plane> existPlaneDbMap = existPlaneDb.stream()
                 .collect(Collectors.toMap(
                         p -> p.getFlightId() + "_" + p.getScheduleDateTime(),
@@ -46,16 +42,14 @@ public class PlaneService {
                         (a, b) -> a
                 ));
 
-        // DB에 저장할 신규 항공편 데이터를 담는 리스트
         List<Plane> toSave = new ArrayList<>();
         processPlaneItems(jsonPlaneData, existPlaneDbMap, searchDate, toSave);
 
         planeRepository.saveAll(toSave);
 
-        // 신규 항공편 ES 인덱싱용 Kafka 메시지 발행 ( saveAll 이후 ID가 생성되기 때문 )
+        // 신규 항공편 ES 인덱싱 이벤트 발행 (saveAll 이후 ID가 생성되므로 이 시점에 생성)
         for (Plane plane : toSave) {
-            kafkaTemplate.send(TOPIC_INDEXING, plane.getFlightId(),
-                    PlaneIndexingMessage.from(plane));
+            eventPublisher.publishEvent(FlightIndexingEvent.from(plane));
         }
     }
 
@@ -66,83 +60,63 @@ public class PlaneService {
      * 이 경우 새로운 데이터는 저장하지 않고 갱신 여부만 확인
      */
     private void processPlaneItems(JsonNode items, Map<String, Plane> existPlaneDbMap, String searchDate, List<Plane> planesToSave) {
-        // API 응답 내 동일 항공편 중복 제거용 ( JSON 데이터 중 중복되는 정보가 있는 경우가 있기 때문 )
+        // API 응답 내 동일 항공편 중복 제거용 (JSON 데이터 중 중복되는 정보가 있는 경우가 있기 때문)
         Set<String> checkDuplication = new HashSet<>();
 
         for (JsonNode item : items) {
-            // 항공편 중 codeshare 값이 "Master"가 아니라면 유효하지 않은 것이므로 제외
+            // codeshare 값이 "Master"가 아니라면 유효하지 않은 항공편이므로 제외
             if (!item.path("codeshare").asText().equals("Master")) continue;
 
-            // key 값
             String key = item.path("flightId").asText() + "_" + item.path("scheduleDateTime").asText();
 
-            // 중복 데이터 제외
             if (!checkDuplication.add(key)) continue;
 
-            // 이미 DB에 존재하는 항공편인지 확인
             Plane existingPlane = existPlaneDbMap.get(key);
 
-            // 이미 DB에 존재하는 항공편이라면 수정 여부 파악
             if (existingPlane != null) {
-                String newRemark = item.path("remark").asText();
-                String newEstimatedDateTime = item.path("estimatedDateTime").asText();
-                String newGatenumber = item.path("gatenumber").asText();
-                String newTerminalId = item.path("terminalid").asText();
-                String newChkinrange = item.path("chkinrange").asText();
-
-                // 변경 여부 파악
-                boolean changed = hasPlaneChanged(
-                        existingPlane,
-                        newRemark,
-                        newEstimatedDateTime,
-                        newGatenumber,
-                        newTerminalId,
-                        newChkinrange
-                );
-
-                if (changed) { // 데이터가 변경되었다면
-                    // Dirty Checking으로 수정
-                    existingPlane.updatePlane(
-                            newRemark,
-                            newEstimatedDateTime,
-                            newGatenumber,
-                            newTerminalId,
-                            newChkinrange
-                    );
-
-                    // 알림용 Kafka 메시지 발행하여 알림 발송되도록
-                    kafkaTemplate.send(TOPIC_CHANGED, existingPlane.getFlightId(),
-                            PlaneChangedMessage.from(existingPlane, newRemark, newEstimatedDateTime, newGatenumber, newTerminalId, newChkinrange));
-
-                    // ES 인덱싱용 Kafka 메시지 즉시 발행
-                    kafkaTemplate.send(TOPIC_INDEXING, existingPlane.getFlightId(),
-                            PlaneIndexingMessage.from(existingPlane));
-                }
-
-            // 신규 데이터
+                updateExistingIfChanged(existingPlane, item);
             } else {
-                // 어제 날짜의 신규 데이터는 제외
-                LocalDate targetDate = LocalDate.parse(searchDate, DateUtils.BASIC_DATE);
-                if (targetDate.equals(LocalDate.now().minusDays(1))) continue;
-
-                Plane newPlane = Plane.builder()
-                        .searchDate(searchDate)
-                        .flightId(item.path("flightId").asText())
-                        .airLine(item.path("airline").asText())
-                        .airport(item.path("airport").asText())
-                        .airportCode(item.path("airportCode").asText())
-                        .scheduleDateTime(item.path("scheduleDateTime").asText())
-                        .estimatedDateTime(item.path("estimatedDateTime").asText())
-                        .gatenumber(item.path("gatenumber").asText())
-                        .terminalid(item.path("terminalid").asText())
-                        .remark(item.path("remark").asText())
-                        .codeShare(item.path("codeshare").asText())
-                        .chkinrange(item.path("chkinrange").asText())
-                        .build();
-
-                planesToSave.add(newPlane);
+                buildNewPlaneIfApplicable(item, searchDate).ifPresent(planesToSave::add);
             }
         }
+    }
+
+    // 기존 항공편 변경 여부를 확인하고, 변경된 경우에만 업데이트 및 이벤트 발행
+    private void updateExistingIfChanged(Plane existingPlane, JsonNode item) {
+        String newRemark = item.path("remark").asText();
+        String newEstimatedDateTime = item.path("estimatedDateTime").asText();
+        String newGatenumber = item.path("gatenumber").asText();
+        String newTerminalId = item.path("terminalid").asText();
+        String newChkinrange = item.path("chkinrange").asText();
+
+        if (!hasPlaneChanged(existingPlane, newRemark, newEstimatedDateTime, newGatenumber, newTerminalId, newChkinrange)) {
+            return;
+        }
+
+        existingPlane.updatePlane(newRemark, newEstimatedDateTime, newGatenumber, newTerminalId, newChkinrange);
+        eventPublisher.publishEvent(PlaneChangedEvent.from(existingPlane, newRemark, newEstimatedDateTime, newGatenumber));
+        eventPublisher.publishEvent(FlightIndexingEvent.from(existingPlane));
+    }
+
+    // 신규 항공편 생성 — 어제 날짜의 신규 데이터는 제외
+    private Optional<Plane> buildNewPlaneIfApplicable(JsonNode item, String searchDate) {
+        LocalDate targetDate = LocalDate.parse(searchDate, DateUtils.BASIC_DATE);
+        if (targetDate.equals(LocalDate.now().minusDays(1))) return Optional.empty();
+
+        return Optional.of(Plane.builder()
+                .searchDate(searchDate)
+                .flightId(item.path("flightId").asText())
+                .airLine(item.path("airline").asText())
+                .airport(item.path("airport").asText())
+                .airportCode(item.path("airportCode").asText())
+                .scheduleDateTime(item.path("scheduleDateTime").asText())
+                .estimatedDateTime(item.path("estimatedDateTime").asText())
+                .gatenumber(item.path("gatenumber").asText())
+                .terminalid(item.path("terminalid").asText())
+                .remark(item.path("remark").asText())
+                .codeShare(item.path("codeshare").asText())
+                .chkinrange(item.path("chkinrange").asText())
+                .build());
     }
 
     // Plane 엔티티 변경 여부
@@ -161,54 +135,31 @@ public class PlaneService {
                 || !Objects.equals(existingPlane.getChkinrange(), newChkinrange);
     }
 
-    // 특정 날의 항공편 데이터 목록 조회
     public List<Plane> getPlanesBySearchDate(String searchDate) {
         return planeRepository.findBySearchDate(searchDate);
     }
 
     public Slice<PlaneResDto> getSlicePlanesBySearchDate(String date, int page, int size) {
-
         Pageable pageable = PageRequest.of(page, size, Sort.by("scheduleDateTime").ascending());
-
         Slice<Plane> slicePlane = planeRepository.findBySearchDate(date, pageable);
-
         return slicePlane.map(PlaneResDto::from);
     }
 
-    // 스케줄러를 통해 매 자정에 이틀 전 항공편 삭제 ( 출발 상태의 항공편만 삭제 )
-    @Transactional
-    public void cleanUpPlaneData() {
-        String twoDaysAgo = LocalDate.now().minusDays(2).format(DateUtils.BASIC_DATE);
-        String yesterday = LocalDate.now().minusDays(1).format(DateUtils.BASIC_DATE);
-
-        // DB: 이틀 전 & 출발 상태 항공편 삭제
-        planeRepository.deleteBySearchDateAndRemark(twoDaysAgo, "출발");
-        log.debug("{} 날짜의 출발 완료 항공편 데이터 정리 완료", twoDaysAgo);
-
-        // ES: 어제 출발 완료 항공편 문서 삭제
-        try {
-            long deleted = flightSearchService.deleteBySearchDateAndRemark(yesterday, "출발");
-            log.debug("{} 날짜 ES 인덱스 문서 {}건 삭제 완료", yesterday, deleted);
-        } catch (Exception e) {
-            log.error("{} 날짜 ES 인덱스 문서 삭제 실패", yesterday, e);
-        }
-    }
-
-    // 모든 항공편 데이터 삭제
     @Transactional
     public void deleteAll() {
         planeRepository.deleteAll();
     }
 
-    // DB의 모든 항공편 데이터를 Kafka로 재발행하여 ES 재인덱싱
+    // DB의 모든 항공편 데이터를 이벤트로 재발행하여 ES 재인덱싱
+    @Transactional
     public int reindexAll() {
         List<Plane> allPlanes = planeRepository.findAll();
 
         for (Plane plane : allPlanes) {
-            kafkaTemplate.send(TOPIC_INDEXING, plane.getFlightId(), PlaneIndexingMessage.from(plane));
+            eventPublisher.publishEvent(FlightIndexingEvent.from(plane));
         }
 
-        log.info("ES 재인덱싱 Kafka 메시지 발행 완료: {}건", allPlanes.size());
+        log.info("ES 재인덱싱 이벤트 발행 완료: {}건", allPlanes.size());
         return allPlanes.size();
     }
 }

--- a/src/main/java/com/example/chat/airport/plane/repository/PlaneRepository.java
+++ b/src/main/java/com/example/chat/airport/plane/repository/PlaneRepository.java
@@ -4,9 +4,6 @@ import com.example.chat.airport.plane.Plane;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,9 +11,5 @@ public interface PlaneRepository extends JpaRepository<Plane, Long> {
 
     List<Plane> findBySearchDate(String searchDate);
 
-    // searchDate, remark를 지정하여 항공편 삭제
-    void deleteBySearchDateAndRemark(String searchDate, String remark);
-
     Slice<Plane> findBySearchDate(String searchDate, Pageable pageable);
 }
-

--- a/src/main/java/com/example/chat/config/SecurityConfig.java
+++ b/src/main/java/com/example/chat/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.example.chat.auth.oauth.CustomSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;

--- a/src/test/java/com/example/chat/SearchBenchmarkTest.java
+++ b/src/test/java/com/example/chat/SearchBenchmarkTest.java
@@ -1,0 +1,351 @@
+/*
+package com.example.chat;
+
+import com.example.chat.airport.plane.Plane;
+import com.example.chat.airport.plane.repository.PlaneRepository;
+import com.example.chat.airport.search.FlightDocument;
+import com.example.chat.airport.search.FlightSearchRepository;
+import com.example.chat.airport.search.FlightSearchService;
+import com.example.chat.airport.search.dto.FlightSearchResDto;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+@ActiveProfiles("test")
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration"
+})
+@MockitoBean(types = KafkaTemplate.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SearchBenchmarkTest {
+
+    @Autowired
+    private PlaneRepository planeRepository;
+
+    @Autowired
+    private FlightSearchService flightSearchService;
+
+    @Autowired
+    private FlightSearchRepository flightSearchRepository;
+
+    @Autowired
+    private ElasticsearchOperations elasticsearchOperations;
+
+    private static final int WARMUP_RUNS = 30;
+    private static final int MEASURE_RUNS = 200;
+    private static final String TODAY = "20260421";
+
+    private static final int DUMMY_COUNT = 50_000;
+    private static final int BATCH_SIZE = 1_000;
+
+    private static final String[] AIRLINES = {"대한항공", "아시아나항공", "진에어", "제주항공", "티웨이항공", "에어부산", "에어서울"};
+    private static final String[] AIRLINE_CODES = {"KE", "OZ", "LJ", "7C", "TW", "BX", "RS"};
+    private static final String[] AIRPORTS = {"나리타", "하네다", "간사이", "푸동", "수완나품", "창이", "히드로", "샤를드골", "프랑크푸르트", "로스앤젤레스"};
+    private static final String[] SEARCH_DATES = {"20260420", "20260421", "20260422", "20260423", "20260424", "20260425"};
+    private static final String[] TERMINALS = {"P01", "P03"};
+    private static final String[] REMARKS = {"출발", "탑승중", "지연", "결항"};
+
+    private final List<Long> dummyPlaneIds = new ArrayList<>();
+
+    @BeforeAll
+    void setUp() {
+        System.out.println("========================================");
+        System.out.println("더미 데이터 " + DUMMY_COUNT + "건 생성 시작...");
+        System.out.println("========================================");
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        List<Plane> planeBatch = new ArrayList<>(BATCH_SIZE);
+        List<FlightDocument> esBatch = new ArrayList<>(BATCH_SIZE);
+
+        for (int i = 0; i < DUMMY_COUNT; i++) {
+            int airlineIdx = random.nextInt(AIRLINES.length);
+            String airLine = AIRLINES[airlineIdx];
+            String airlineCode = AIRLINE_CODES[airlineIdx];
+            String airport = AIRPORTS[random.nextInt(AIRPORTS.length)];
+            String flightId = airlineCode + (random.nextInt(9000) + 100);
+            String searchDate = SEARCH_DATES[random.nextInt(SEARCH_DATES.length)];
+            String terminalid = TERMINALS[random.nextInt(TERMINALS.length)];
+            String remark = REMARKS[random.nextInt(REMARKS.length)];
+            int hour = random.nextInt(6, 24);
+            int minute = random.nextInt(0, 60);
+            String scheduleDateTime = String.format("%02d%02d", hour, minute);
+
+            Plane plane = Plane.builder()
+                    .searchDate(searchDate)
+                    .flightId(flightId)
+                    .airLine(airLine)
+                    .airport(airport)
+                    .airportCode(airlineCode)
+                    .scheduleDateTime(scheduleDateTime)
+                    .estimatedDateTime(scheduleDateTime)
+                    .gatenumber(String.valueOf(random.nextInt(1, 50)))
+                    .terminalid(terminalid)
+                    .remark(remark)
+                    .build();
+
+            planeBatch.add(plane);
+
+            if (planeBatch.size() >= BATCH_SIZE) {
+                List<Plane> saved = planeRepository.saveAll(planeBatch);
+                for (Plane savedPlane : saved) {
+                    dummyPlaneIds.add(savedPlane.getId());
+                    esBatch.add(toFlightDocument(savedPlane));
+                }
+                flightSearchRepository.saveAll(esBatch);
+                planeBatch.clear();
+                esBatch.clear();
+            }
+        }
+
+        // 남은 데이터 처리
+        if (!planeBatch.isEmpty()) {
+            List<Plane> saved = planeRepository.saveAll(planeBatch);
+            for (Plane savedPlane : saved) {
+                dummyPlaneIds.add(savedPlane.getId());
+                esBatch.add(toFlightDocument(savedPlane));
+            }
+            flightSearchRepository.saveAll(esBatch);
+        }
+
+        // ES 인덱스 refresh
+        IndexOperations indexOps = elasticsearchOperations.indexOps(IndexCoordinates.of("flights"));
+        indexOps.refresh();
+
+        System.out.println("더미 데이터 생성 완료: MySQL " + dummyPlaneIds.size() + "건, ES 동기화 완료");
+    }
+
+    @AfterAll
+    void tearDown() {
+        System.out.println("========================================");
+        System.out.println("더미 데이터 정리 시작...");
+        System.out.println("========================================");
+
+        // MySQL 삭제 (배치)
+        for (int i = 0; i < dummyPlaneIds.size(); i += BATCH_SIZE) {
+            List<Long> batch = dummyPlaneIds.subList(i, Math.min(i + BATCH_SIZE, dummyPlaneIds.size()));
+            planeRepository.deleteAllByIdInBatch(batch);
+        }
+
+        // ES 삭제 (배치)
+        List<FlightDocument> esDocs = new ArrayList<>();
+        for (Long id : dummyPlaneIds) {
+            // ES에서는 id 기반 삭제가 필요하므로 dummy doc으로 deleteAll 호출
+        }
+        // 전체 인덱스를 다시 빌드하는 대신, 테스트 환경이므로 deleteAll 사용
+        flightSearchRepository.deleteAll();
+
+        System.out.println("더미 데이터 정리 완료");
+    }
+
+    private FlightDocument toFlightDocument(Plane plane) {
+        String suggest = String.join(" ",
+                plane.getFlightId(),
+                plane.getAirLine(),
+                plane.getAirport(),
+                plane.getAirportCode() != null ? plane.getAirportCode() : ""
+        );
+
+        return FlightDocument.builder()
+                .id(plane.getFlightId() + "_" + plane.getScheduleDateTime())
+                .planeId(String.valueOf(plane.getId()))
+                .flightId(plane.getFlightId())
+                .airLine(plane.getAirLine())
+                .airport(plane.getAirport())
+                .airportCode(plane.getAirportCode())
+                .scheduleDateTime(plane.getScheduleDateTime())
+                .estimatedDateTime(plane.getEstimatedDateTime())
+                .gatenumber(plane.getGatenumber())
+                .terminalid(plane.getTerminalid())
+                .remark(plane.getRemark())
+                .searchDate(plane.getSearchDate())
+                .suggest(suggest)
+                .build();
+    }
+
+    @Test
+    void 항공사명_검색_벤치마크() {
+        runBenchmark(
+                "항공사명 검색 (\"대한\")",
+                () -> planeRepository.searchByAirLine("대한"),
+                () -> flightSearchService.searchByAirLineOnly("대한")
+        );
+    }
+
+    @Test
+    void 항공사명_날짜_복합_검색_벤치마크() {
+        runBenchmark(
+                "항공사 + 날짜 검색 (\"대한\" + \"" + TODAY + "\")",
+                () -> planeRepository.searchByAirLineAndSearchDate("대한", TODAY),
+                () -> flightSearchService.searchByAirLineAndDate("대한", TODAY)
+        );
+    }
+
+    @Test
+    void flightId_prefix_검색_벤치마크() {
+        runBenchmark(
+                "flightId prefix 검색 (\"KE\")",
+                () -> planeRepository.searchByFlightIdPrefix("KE"),
+                () -> flightSearchService.searchByFlightIdPrefix("KE")
+        );
+    }
+
+    @Test
+    void 공항명_검색_벤치마크() {
+        runBenchmark(
+                "공항명 검색 (\"나리타\")",
+                () -> planeRepository.searchByAirport("나리타"),
+                () -> flightSearchService.searchByAirportOnly("나리타")
+        );
+    }
+
+    @Test
+    void 날짜_단일_필터_벤치마크() {
+        runBenchmark(
+                "날짜 단일 필터 (\"" + TODAY + "\")",
+                () -> planeRepository.findBySearchDate(TODAY),
+                () -> flightSearchService.searchByDateOnly(TODAY)
+        );
+    }
+
+    @Test
+    void 복합_조건_검색_벤치마크() {
+        runBenchmark(
+                "복합 조건 검색 (\"대한\" + \"" + TODAY + "\" + \"P01\")",
+                () -> planeRepository.searchComplex("대한", TODAY, "P01"),
+                () -> flightSearchService.searchComplex("대한", TODAY, "P01")
+        );
+    }
+
+    private <T> void runBenchmark(
+            String scenarioName,
+            Supplier<List<T>> mysqlQuery,
+            Supplier<?> esQuery
+    ) {
+        System.out.println("\n========================================");
+        System.out.println("시나리오: " + scenarioName);
+        System.out.println("========================================");
+
+        // 1) 결과 개수 확인
+        List<T> mysqlSample = mysqlQuery.get();
+        Object esSample = esQuery.get();
+
+        int mysqlCount = mysqlSample != null ? mysqlSample.size() : -1;
+        int esCount = extractSize(esSample);
+
+        System.out.printf("MySQL 결과 수: %d%n", mysqlCount);
+        System.out.printf("ES 결과 수   : %d%n", esCount);
+
+        // 2) 워밍업
+        for (int i = 0; i < WARMUP_RUNS; i++) {
+            consume(mysqlQuery.get());
+            consume(esQuery.get());
+        }
+
+        // 3) 측정
+        long[] mysqlTimes = measure(mysqlQuery, MEASURE_RUNS);
+        long[] esTimes = measure(esQuery, MEASURE_RUNS);
+
+        BenchmarkStats mysqlStats = BenchmarkStats.from("MySQL", mysqlTimes);
+        BenchmarkStats esStats = BenchmarkStats.from("Elasticsearch", esTimes);
+
+        // 4) 출력
+        System.out.println("----------------------------------------");
+        mysqlStats.print();
+        esStats.print();
+        System.out.println("----------------------------------------");
+
+        double avgRatio = mysqlStats.avgMs / esStats.avgMs;
+        double p95Ratio = mysqlStats.p95Ms / esStats.p95Ms;
+
+        System.out.printf("평균 기준 ES가 %.2fx 빠름%n", avgRatio);
+        System.out.printf("p95 기준 ES가 %.2fx 빠름%n", p95Ratio);
+    }
+
+    private long[] measure(Supplier<?> query, int runs) {
+        long[] times = new long[runs];
+
+        for (int i = 0; i < runs; i++) {
+            long start = System.nanoTime();
+            Object result = query.get();
+            long end = System.nanoTime();
+
+            consume(result);
+            times[i] = end - start;
+        }
+
+        return times;
+    }
+
+    private void consume(Object result) {
+        if (result instanceof List<?> list) {
+            // 결과를 한 번은 읽어줘서 측정 왜곡 방지
+            int size = list.size();
+            if (size > 0) {
+                Object first = list.get(0);
+                first.hashCode();
+            }
+        } else if (result != null) {
+            result.hashCode();
+        }
+    }
+
+    private int extractSize(Object result) {
+        if (result instanceof List<?> list) {
+            return list.size();
+        }
+        return -1;
+    }
+
+    private static class BenchmarkStats {
+        private final String name;
+        private final double avgMs;
+        private final double minMs;
+        private final double maxMs;
+        private final double p95Ms;
+
+        private BenchmarkStats(String name, double avgMs, double minMs, double maxMs, double p95Ms) {
+            this.name = name;
+            this.avgMs = avgMs;
+            this.minMs = minMs;
+            this.maxMs = maxMs;
+            this.p95Ms = p95Ms;
+        }
+
+        static BenchmarkStats from(String name, long[] nanos) {
+            long[] sorted = Arrays.copyOf(nanos, nanos.length);
+            Arrays.sort(sorted);
+
+            long total = 0;
+            for (long nano : sorted) {
+                total += nano;
+            }
+
+            double avgMs = total / (double) sorted.length / 1_000_000.0;
+            double minMs = sorted[0] / 1_000_000.0;
+            double maxMs = sorted[sorted.length - 1] / 1_000_000.0;
+
+            int p95Index = (int) Math.ceil(sorted.length * 0.95) - 1;
+            double p95Ms = sorted[Math.max(p95Index, 0)] / 1_000_000.0;
+
+            return new BenchmarkStats(name, avgMs, minMs, maxMs, p95Ms);
+        }
+
+        void print() {
+            System.out.printf(
+                    "%-13s → avg: %8.3f ms | min: %8.3f ms | p95: %8.3f ms | max: %8.3f ms%n",
+                    name, avgMs, minMs, p95Ms, maxMs
+            );
+        }
+    }
+}
+*/


### PR DESCRIPTION
## 변경 내용

**PlaneChangedEvent**
- 미사용 필드 6개 제거: `terminalid`, `searchDate`, `prevChkinrange`, `prevTerminalId`, `newTerminalId`, `newChkinrange`
- 버그 수정: `prevTerminalId`와 `terminalid` 모두 `plane.getTerminalid()`로 같은 값을 담던 중복 할당 제거
- `from()` 파라미터 6개 → 4개로 단순화

**PlaneRepository**
- 벤치마크 테스트 전용이었던 메서드 6개 제거: `searchByAirLine`, `searchByAirLineAndSearchDate`, `searchByFlightIdPrefix`, `searchByAirport`, `searchComplex`, `deleteBySearchDateAndRemark`

**PlaneController → ApiService 책임 이동**
- `syncAllPlanes()`의 날짜 루프 로직을 `ApiService.syncPlaneDataForDays()`로 이동
- Controller는 위임만 담당

**PlaneService — processPlaneItems 분리**
- `updateExistingIfChanged(Plane, JsonNode)`: 변경 감지 + 업데이트 + 이벤트 발행
- `buildNewPlaneIfApplicable(JsonNode, String)`: 신규 Plane 생성 (`Optional<Plane>` 반환)